### PR TITLE
Fix GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: 📊 Upload coverage to Codecov
         if: matrix.node-version == '20.x'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -59,7 +59,7 @@ jobs:
 
       - name: 💾 Archive coverage reports
         if: matrix.node-version == '20.x'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage/
@@ -119,7 +119,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
       - name: 💾 Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: .next/
@@ -170,7 +170,7 @@ jobs:
         run: npm ci
 
       - name: 📥 Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: .next/


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4
- Update actions/download-artifact from v3 to v4
- Update codecov/codecov-action from v3 to v4

These updates resolve the deprecation notice for v3 artifact actions as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/