### PR TITLE
Fix Slack notification action warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,6 @@ jobs:
             Commit: ${{ github.sha }}
             Author: ${{ github.actor }}
             Message: ${{ github.event.head_commit.message }}
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
Remove invalid 'webhook_url' parameter from Slack action. The action only accepts SLACK_WEBHOOK_URL as an environment variable.