### PR TITLE
Fix GitHub Actions artifact download issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
     name: Build Application
     runs-on: ubuntu-latest
     needs: [test, lint]
+    if: always()
     
     steps:
       - name: 📥 Checkout code
@@ -154,7 +155,7 @@ jobs:
     name: Performance Tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.build.result == 'success'
     
     steps:
       - name: 📥 Checkout code
@@ -174,10 +175,19 @@ jobs:
         with:
           name: build-artifacts
           path: .next/
+        continue-on-error: true
+
+      - name: 🏗️ Build if artifacts not found
+        run: |
+          if [ ! -d ".next" ]; then
+            echo "Build artifacts not found, building locally..."
+            npm run build
+          fi
+        env:
+          NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
 
       - name: 🚀 Start application
         run: |
-          npm run build
           npm start &
           sleep 10
         env:


### PR DESCRIPTION
- Make build job run always (even if tests fail) with if: always()
- Make performance job conditional on build success
- Add fallback build if artifacts not found
- Use continue-on-error for artifact download

This ensures the pipeline continues even when artifacts are missing