### PR TITLE
Fix Lighthouse artifact upload conflict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
             http://localhost:3000
             http://localhost:3000/verkrijgbaar
             http://localhost:3000/tips
-          uploadArtifacts: true
+          uploadArtifacts: false
           temporaryPublicStorage: true
 
   deploy-preview:


### PR DESCRIPTION
- Disable uploadArtifacts in Lighthouse CI action
- Keep temporaryPublicStorage for results visibility
- Prevents 'artifact name is not valid' error

The artifact upload was failing because multiple URLs were creating conflicting artifact names. Disabling artifact upload resolves this.