### PR TITLE
Make Slack notification optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,7 @@ jobs:
     
     steps:
       - name: 📢 Slack Notification
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.SLACK_WEBHOOK != ''
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -261,6 +261,7 @@ jobs:
             Message: ${{ github.event.head_commit.message }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        continue-on-error: true
 
       - name: 📝 Create summary
         run: |


### PR DESCRIPTION
- Check if SLACK_WEBHOOK secret exists before running
- Add continue-on-error to prevent job failure
- Only runs when secret is configured

This prevents the pipeline from failing when Slack is not configured